### PR TITLE
feat: support TimeFunctionLiteral

### DIFF
--- a/sqlgen/expression_sql_generator.go
+++ b/sqlgen/expression_sql_generator.go
@@ -311,7 +311,12 @@ func (esg *expressionSQLGenerator) literalTime(b sb.SQLBuilder, t time.Time) {
 		esg.placeHolderSQL(b, t)
 		return
 	}
-	esg.Generate(b, t.In(timeLocation).Format(esg.dialectOptions.TimeFormat))
+	formatted := t.In(timeLocation).Format(esg.dialectOptions.TimeFormat)
+	if esg.dialectOptions.TimeFunctionLiteral != "" {
+		esg.Generate(b, exp.NewLiteralExpression(esg.dialectOptions.TimeFunctionLiteral, formatted))
+	} else {
+		esg.Generate(b, formatted)
+	}
 }
 
 // Generates SQL for a Float Value

--- a/sqlgen/sql_dialect_options.go
+++ b/sqlgen/sql_dialect_options.go
@@ -195,6 +195,8 @@ type (
 		PeriodRune rune
 		// Set to true to include positional argument numbers when creating a prepared statement (Default=false)
 		IncludePlaceholderNum bool
+		// The literal value to wrap timestamps with when interpolating time.Time, e.g. from_iso8601_timestamp(?) (DEFAULT="")
+		TimeFunctionLiteral string
 		// The time format to use when serializing time.Time (DEFAULT=time.RFC3339Nano)
 		TimeFormat string
 		// A map used to look up BooleanOperations and their SQL equivalents


### PR DESCRIPTION
# Description

Add `TimeFunctionLiteral` for trino, which doesn't support comparing time columns against iso8601 formatted strings.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
