### PR TITLE
fix: in operator wraps a subquery in double parenthesis

### DIFF
--- a/exp/bool.go
+++ b/exp/bool.go
@@ -71,16 +71,26 @@ func lte(lhs Expression, rhs interface{}) BooleanExpression {
 
 // used internally to create an IN BooleanExpression
 func in(lhs Expression, vals ...interface{}) BooleanExpression {
-	if len(vals) == 1 && reflect.Indirect(reflect.ValueOf(vals[0])).Kind() == reflect.Slice {
-		return NewBooleanExpression(InOp, lhs, vals[0])
+	if len(vals) == 1 {
+		if reflect.Indirect(reflect.ValueOf(vals[0])).Kind() == reflect.Slice {
+			return NewBooleanExpression(InOp, lhs, vals[0])
+		}
+		if _, ok := vals[0].(AppendableExpression); ok {
+			return NewBooleanExpression(InOp, lhs, vals[0])
+		}
 	}
 	return NewBooleanExpression(InOp, lhs, vals)
 }
 
 // used internally to create a NOT IN BooleanExpression
 func notIn(lhs Expression, vals ...interface{}) BooleanExpression {
-	if len(vals) == 1 && reflect.Indirect(reflect.ValueOf(vals[0])).Kind() == reflect.Slice {
-		return NewBooleanExpression(NotInOp, lhs, vals[0])
+	if len(vals) == 1 {
+		if reflect.Indirect(reflect.ValueOf(vals[0])).Kind() == reflect.Slice {
+			return NewBooleanExpression(NotInOp, lhs, vals[0])
+		}
+		if _, ok := vals[0].(AppendableExpression); ok {
+			return NewBooleanExpression(NotInOp, lhs, vals[0])
+		}
 	}
 	return NewBooleanExpression(NotInOp, lhs, vals)
 }

--- a/expressions_example_test.go
+++ b/expressions_example_test.go
@@ -245,6 +245,9 @@ func ExampleC_inOperators() {
 	// using identifiers
 	sql, _, _ := goqu.From("test").Where(goqu.C("a").In("a", "b", "c")).ToSQL()
 	fmt.Println(sql)
+	// with a single element
+	sql, _, _ = goqu.From("test").Where(goqu.C("a").In("a")).ToSQL()
+	fmt.Println(sql)
 	// with a slice
 	sql, _, _ = goqu.From("test").Where(goqu.C("a").In([]string{"a", "b", "c"})).ToSQL()
 	fmt.Println(sql)
@@ -254,12 +257,17 @@ func ExampleC_inOperators() {
 	// with a slice
 	sql, _, _ = goqu.From("test").Where(goqu.C("a").NotIn([]string{"a", "b", "c"})).ToSQL()
 	fmt.Println(sql)
+	// with a subquery
+	sql, _, _ = goqu.From("test").Where(goqu.C("a").NotIn(goqu.Select("a").From("test_b").Expression())).ToSQL()
+	fmt.Println(sql)
 
 	// Output:
 	// SELECT * FROM "test" WHERE ("a" IN ('a', 'b', 'c'))
+	// SELECT * FROM "test" WHERE ("a" IN ('a'))
 	// SELECT * FROM "test" WHERE ("a" IN ('a', 'b', 'c'))
 	// SELECT * FROM "test" WHERE ("a" NOT IN ('a', 'b', 'c'))
 	// SELECT * FROM "test" WHERE ("a" NOT IN ('a', 'b', 'c'))
+	// SELECT * FROM "test" WHERE ("a" NOT IN (SELECT "a" FROM "test_b"))
 }
 
 func ExampleC_likeComparisons() {

--- a/sqlgen/expression_sql_generator_test.go
+++ b/sqlgen/expression_sql_generator_test.go
@@ -571,16 +571,16 @@ func (esgs *expressionSQLGeneratorSuite) TestGenerate_BooleanExpression() {
 			int64(1), int64(2), int64(3),
 		}},
 
-		expressionTestCase{val: ident.In(ae), sql: `("a" IN ((SELECT "id" FROM "test2")))`},
-		expressionTestCase{val: ident.In(ae), sql: `("a" IN ((SELECT "id" FROM "test2")))`, isPrepared: true},
+		expressionTestCase{val: ident.In(ae), sql: `("a" IN (SELECT "id" FROM "test2"))`},
+		expressionTestCase{val: ident.In(ae), sql: `("a" IN (SELECT "id" FROM "test2"))`, isPrepared: true},
 
 		expressionTestCase{val: ident.NotIn([]int64{1, 2, 3}), sql: `("a" NOT IN (1, 2, 3))`},
 		expressionTestCase{val: ident.NotIn([]int64{1, 2, 3}), sql: `("a" NOT IN (?, ?, ?))`, isPrepared: true, args: []interface{}{
 			int64(1), int64(2), int64(3),
 		}},
 
-		expressionTestCase{val: ident.NotIn(ae), sql: `("a" NOT IN ((SELECT "id" FROM "test2")))`},
-		expressionTestCase{val: ident.NotIn(ae), sql: `("a" NOT IN ((SELECT "id" FROM "test2")))`, isPrepared: true},
+		expressionTestCase{val: ident.NotIn(ae), sql: `("a" NOT IN (SELECT "id" FROM "test2"))`},
+		expressionTestCase{val: ident.NotIn(ae), sql: `("a" NOT IN (SELECT "id" FROM "test2"))`, isPrepared: true},
 
 		expressionTestCase{val: ident.Like("a%"), sql: `("a" LIKE 'a%')`},
 		expressionTestCase{val: ident.Like("a%"), sql: `("a" LIKE ?)`, isPrepared: true, args: []interface{}{"a%"}},


### PR DESCRIPTION
# Description

Skipping the extra parenthesis in `IN` and `NOT IN` clauses in case of appendable expressions, as double parenthesis cause issues with databricks.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
